### PR TITLE
Fix data display for schools and programs

### DIFF
--- a/app/api/programs/[id]/route.ts
+++ b/app/api/programs/[id]/route.ts
@@ -20,7 +20,7 @@ export async function GET(
       );
     }
 
-    return NextResponse.json({ program });
+    return NextResponse.json(program);
   } catch (error) {
     console.error('Error fetching program:', error);
     return NextResponse.json(

--- a/app/api/scholarships/[id]/route.ts
+++ b/app/api/scholarships/[id]/route.ts
@@ -20,7 +20,7 @@ export async function GET(
       );
     }
 
-    return NextResponse.json({ scholarship });
+    return NextResponse.json(scholarship);
   } catch (error) {
     console.error('Error fetching scholarship:', error);
     return NextResponse.json(

--- a/app/api/schools/[id]/route.ts
+++ b/app/api/schools/[id]/route.ts
@@ -33,7 +33,7 @@ export async function GET(
       );
     }
 
-    return NextResponse.json({ school });
+    return NextResponse.json(transformSchool(school));
   } catch (error) {
     console.error('Error fetching school:', error);
     return NextResponse.json(
@@ -67,7 +67,7 @@ export async function PUT(
 
     return NextResponse.json({
       message: "School updated successfully",
-      school: updatedSchool
+      school: transformSchool(updatedSchool)
     });
   } catch (error) {
     console.error('Error updating school:', error);

--- a/components/forms/ProgramForm.tsx
+++ b/components/forms/ProgramForm.tsx
@@ -120,6 +120,35 @@ export default function ProgramForm({ program, onSubmit, onCancel, isLoading }: 
     fetchSchools();
   }, []);
 
+  // Reset form when program data changes
+  useEffect(() => {
+    if (program) {
+      // Reset the form with the program data
+      Object.keys(program).forEach((key) => {
+        const value = program[key as keyof Program];
+        if (value !== undefined && value !== null) {
+          setValue(key as keyof Program, value);
+        }
+      });
+      // Also update the state variables
+      if (program.schoolId) {
+        const schoolId = typeof program.schoolId === 'object' && program.schoolId !== null && ('_id' in program.schoolId || 'id' in program.schoolId)
+          ? ((program.schoolId as any)?._id || (program.schoolId as any)?.id)
+          : program.schoolId;
+        setSelectedSchoolId(schoolId);
+      }
+      if (program.degreeType) {
+        setSelectedDegreeType(program.degreeType);
+      }
+      if (program.mode) {
+        setSelectedMode(program.mode);
+      }
+      if (program.programLevel) {
+        setProgramLevel(program.programLevel);
+      }
+    }
+  }, [program, setValue]);
+
   const addToArray = (field: string, value: string | { name: string; minScore: number }, setter: (value: any) => void, currentArray: any[]) => {
     if (typeof value === 'string') {
       if (value.trim() && !currentArray.includes(value.trim())) {

--- a/components/forms/ScholarshipForm.tsx
+++ b/components/forms/ScholarshipForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -178,6 +178,26 @@ export default function ScholarshipForm({ scholarship, onSubmit, onCancel, isLoa
     // Clear the value when switching types to avoid confusion
     setValue('value', '');
   };
+
+  // Reset form when scholarship data changes
+  useEffect(() => {
+    if (scholarship) {
+      // Reset the form with the scholarship data
+      Object.keys(scholarship).forEach((key) => {
+        const value = scholarship[key as keyof Scholarship];
+        if (value !== undefined && value !== null) {
+          setValue(key as keyof Scholarship, value);
+        }
+      });
+      // Also update the state variables
+      if (scholarship.frequency) {
+        setSelectedFrequency(scholarship.frequency);
+      }
+      if (scholarship.value !== undefined) {
+        setValueType(typeof scholarship.value === 'number' ? 'number' : 'text');
+      }
+    }
+  }, [scholarship, setValue]);
 
   return (
     <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-8">

--- a/components/forms/SchoolForm.tsx
+++ b/components/forms/SchoolForm.tsx
@@ -170,6 +170,23 @@ export default function SchoolForm({ school, onSubmit, onCancel, isLoading }: Sc
     }
   }, [countryInputRef, countrySearch]);
 
+  // Reset form when school data changes
+  useEffect(() => {
+    if (school) {
+      // Reset the form with the school data
+      Object.keys(school).forEach((key) => {
+        const value = school[key as keyof School];
+        if (value !== undefined && value !== null) {
+          setValue(key as keyof School, value);
+        }
+      });
+      // Also update the campus type state
+      if (school.campusType) {
+        setSelectedCampusType(school.campusType);
+      }
+    }
+  }, [school, setValue]);
+
   return (
     <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-8">
       {/* Basic Information */}


### PR DESCRIPTION
Fixes empty fields on view/edit pages for schools, programs, and scholarships.

The issue was caused by two factors:
1.  API endpoints for individual items (schools, programs, scholarships) were returning data wrapped in an object (e.g., `{ school: {...} }`), but the frontend expected the data directly.
2.  The corresponding form components (`SchoolForm`, `ProgramForm`, `ScholarshipForm`) did not update their `react-hook-form` values when the asynchronously loaded data became available.

This PR updates the APIs to return direct data and adds `useEffect` hooks to the forms to correctly populate fields upon data load.