### PR TITLE
Show temporary layout during page load

### DIFF
--- a/components/programs/ProgramsPage.tsx
+++ b/components/programs/ProgramsPage.tsx
@@ -23,7 +23,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import StudentLayout from '@/components/layout/StudentLayout';
+
 import ProgramCard from './ProgramCard';
 
 interface Program {
@@ -173,21 +173,19 @@ export default function ProgramsPage() {
 
   if (isLoading) {
     return (
-      <StudentLayout>
-        <div className="flex items-center justify-center min-h-[400px]">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            className="text-center"
-          >
-            <div className="w-16 h-16 bg-[#007fbd] rounded-full flex items-center justify-center mx-auto mb-4">
-              <GraduationCap className="w-8 h-8 text-white animate-pulse" />
-            </div>
-            <h2 className="text-2xl font-bold text-gray-900 mb-2">Loading Programs</h2>
-            <p className="text-gray-600">Finding the best academic opportunities...</p>
-          </motion.div>
-        </div>
-      </StudentLayout>
+      <div className="flex items-center justify-center min-h-[400px]">
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="text-center"
+        >
+          <div className="w-16 h-16 bg-[#007fbd] rounded-full flex items-center justify-center mx-auto mb-4">
+            <GraduationCap className="w-8 h-8 text-white animate-pulse" />
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Loading Programs</h2>
+          <p className="text-gray-600">Finding the best academic opportunities...</p>
+        </motion.div>
+      </div>
     );
   }
 

--- a/components/scholarships/ScholarshipsPage.tsx
+++ b/components/scholarships/ScholarshipsPage.tsx
@@ -24,7 +24,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import StudentLayout from '@/components/layout/StudentLayout';
+
 import ScholarshipCard from './ScholarshipCard';
 import ScholarshipFilters from './ScholarshipFilters';
 
@@ -212,21 +212,19 @@ export default function ScholarshipsPage() {
 
   if (isLoading) {
     return (
-      <StudentLayout>
-        <div className="flex items-center justify-center min-h-[400px]">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            className="text-center"
-          >
-            <div className="w-16 h-16 bg-[#007fbd] rounded-full flex items-center justify-center mx-auto mb-4">
-              <Award className="w-8 h-8 text-white animate-pulse" />
-            </div>
-            <h2 className="text-2xl font-bold text-gray-900 mb-2">Loading Scholarships</h2>
-            <p className="text-gray-600">Finding the best opportunities for you...</p>
-          </motion.div>
-        </div>
-      </StudentLayout>
+      <div className="flex items-center justify-center min-h-[400px]">
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="text-center"
+        >
+          <div className="w-16 h-16 bg-[#007fbd] rounded-full flex items-center justify-center mx-auto mb-4">
+            <Award className="w-8 h-8 text-white animate-pulse" />
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Loading Scholarships</h2>
+          <p className="text-gray-600">Finding the best opportunities for you...</p>
+        </motion.div>
+      </div>
     );
   }
 


### PR DESCRIPTION
Remove redundant `StudentLayout` wrapper from loading states in Programs and Scholarships pages to prevent double layout flash.