### PR TITLE
Clarify scholarship application status messaging

### DIFF
--- a/app/(user-portal)/scholarships/[id]/page.tsx
+++ b/app/(user-portal)/scholarships/[id]/page.tsx
@@ -30,7 +30,8 @@ import {
   Bookmark,
   Share2,
   BookmarkPlus,
-  BookmarkCheck
+  BookmarkCheck,
+  HelpCircle
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -94,6 +95,29 @@ function ScholarshipDetailContent() {
     }
   };
 
+  // Get opening date status
+  const getOpeningDateInfo = (openingDate?: string) => {
+    if (!openingDate) {
+      return { color: 'bg-gray-100 text-gray-800', status: 'Opening date not specified', icon: HelpCircle };
+    }
+    
+    const date = new Date(openingDate);
+    const now = new Date();
+    const diffTime = date.getTime() - now.getTime();
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    
+    if (diffDays < 0) {
+      return { color: 'bg-green-100 text-green-800', status: 'Open', icon: CheckCircle };
+    }
+    if (diffDays <= 7) {
+      return { color: 'bg-blue-100 text-blue-800', status: 'Opening Soon', icon: Clock };
+    }
+    if (diffDays <= 30) {
+      return { color: 'bg-yellow-100 text-yellow-800', status: 'Opening in ' + diffDays + ' days', icon: Calendar };
+    }
+    return { color: 'bg-gray-100 text-gray-800', status: 'Opens in ' + diffDays + ' days', icon: Calendar };
+  };
+
   // Get deadline color and status
   const getDeadlineInfo = (deadline: string) => {
     const date = new Date(deadline);
@@ -120,7 +144,7 @@ function ScholarshipDetailContent() {
     const reasons = [];
     let eligible = true;
 
-    // Check if expired
+    // Check if expired - only deadline matters for eligibility
     const deadline = new Date(scholarship.deadline);
     const now = new Date();
     if (deadline < now) {
@@ -338,8 +362,17 @@ function ScholarshipDetailContent() {
           {/* Key Info Stats Bar */}
           <div className="flex flex-col gap-2 md:gap-4 md:items-end">
             <div className="flex flex-wrap gap-3">
+              {(() => {
+                const openingDateInfo = getOpeningDateInfo(scholarship.openingDate);
+                return (
+                  <div className={`flex items-center gap-1 px-3 py-1 rounded-full text-xs font-semibold ${openingDateInfo.color} border shadow-sm`}>
+                    <openingDateInfo.icon className="h-4 w-4" aria-label="Opening Status" />
+                    <span>{openingDateInfo.status}</span>
+                  </div>
+                );
+              })()}
               <div className={`flex items-center gap-1 px-3 py-1 rounded-full text-xs font-semibold ${deadlineInfo.color} border shadow-sm`}>
-                <deadlineInfo.icon className="h-4 w-4" aria-label="Status" />
+                <deadlineInfo.icon className="h-4 w-4" aria-label="Deadline Status" />
                 <span>{deadlineInfo.status}</span>
               </div>
               <div className="flex items-center gap-1 text-green-100 font-semibold bg-green-700/20 px-3 py-1 rounded-full">
@@ -352,10 +385,6 @@ function ScholarshipDetailContent() {
                   {scholarship.linkedSchool}
                 </div>
               )}
-              <div className="flex items-center gap-1 text-blue-100 font-medium bg-blue-700/20 px-3 py-1 rounded-full">
-                <Calendar className="h-4 w-4" aria-label="Deadline" />
-                {formatDeadline(scholarship.deadline)}
-              </div>
             </div>
           </div>
         </div>
@@ -561,6 +590,18 @@ function ScholarshipDetailContent() {
               </CardTitle>
             </CardHeader>
             <CardContent className="p-6 space-y-4">
+              {/* Opening Date Status */}
+              {(() => {
+                const openingDateInfo = getOpeningDateInfo(scholarship.openingDate);
+                return (
+                  <div className={`flex items-center gap-2 p-3 rounded-lg border text-sm font-semibold ${openingDateInfo.color}`}> 
+                    <openingDateInfo.icon className="h-5 w-5" aria-label="Opening Status" />
+                    <span>{openingDateInfo.status}</span>
+                  </div>
+                );
+              })()}
+              
+              {/* Eligibility Status */}
               <div className={`flex items-center gap-2 p-3 rounded-lg border text-sm font-semibold ${eligibilityCheck.eligible ? 'bg-green-50 border-green-200 text-green-800' : 'bg-red-50 border-red-200 text-red-800'}`}> 
                 {eligibilityCheck.eligible ? (
                   <CheckCircle className="h-5 w-5 text-green-600" aria-label="Eligible" />
@@ -568,7 +609,13 @@ function ScholarshipDetailContent() {
                   <AlertCircle className="h-5 w-5 text-red-600" aria-label="Not Eligible" />
                 )}
                 {eligibilityCheck.eligible ? 'Eligible to Apply' : 'Not Eligible'}
+                {!eligibilityCheck.eligible && eligibilityCheck.reasons.length > 0 && (
+                  <div className="text-xs mt-1">
+                    {eligibilityCheck.reasons.join(', ')}
+                  </div>
+                )}
               </div>
+              
               <div className="flex flex-col gap-2">
                 <Button 
                   className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold transition-all" 
@@ -609,6 +656,18 @@ function ScholarshipDetailContent() {
                   Share
                 </Button>
               </div>
+              {scholarship.openingDate && (
+                <div className="flex items-center gap-2 text-blue-700">
+                  <Calendar className="h-4 w-4 text-blue-600" />
+                  <span className="font-medium">Opens:</span>
+                  <span>{new Date(scholarship.openingDate).toLocaleDateString('en-US', { 
+                    weekday: 'long',
+                    year: 'numeric', 
+                    month: 'long', 
+                    day: 'numeric'
+                  })}</span>
+                </div>
+              )}
               <div className="flex items-center gap-2 text-gray-700">
                 <Calendar className="h-4 w-4 text-orange-600" />
                 <span className="font-medium">Deadline:</span>

--- a/app/admin/scholarships/[id]/page.tsx
+++ b/app/admin/scholarships/[id]/page.tsx
@@ -234,6 +234,7 @@ const ScholarshipViewPage = ({ params }: { params: Promise<{ id: string }> }) =>
           <h2 className="text-lg md:text-xl font-semibold text-blue-900">Other Details</h2>
         </div>
         <dl className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
+          <div><dt className="font-semibold text-gray-700">Opening Date</dt><dd className="text-gray-900">{show(scholarship.openingDate)}</dd></div>
           <div><dt className="font-semibold text-gray-700">Deadline</dt><dd className="text-gray-900">{show(scholarship.deadline)}</dd></div>
           <div><dt className="font-semibold text-gray-700">Application Link</dt><dd>{scholarship.applicationLink ? <a href={scholarship.applicationLink} className="text-blue-600 underline hover:text-blue-800 transition" target="_blank" rel="noopener noreferrer"><Link2 className="inline w-4 h-4 mr-1" />Apply Here</a> : <span className="text-gray-400">Not provided</span>}</dd></div>
           <div><dt className="font-semibold text-gray-700">Selection Criteria</dt><dd className="text-gray-900">{show(scholarship.selectionCriteria)}</dd></div>

--- a/models/Scholarship.ts
+++ b/models/Scholarship.ts
@@ -32,6 +32,7 @@ export interface IScholarship extends Document {
     documentsToSubmit?: string[];
   };
   deadline: string;
+  openingDate?: string; // When applications open
   applicationLink: string;
   selectionCriteria: string[];
   renewalConditions?: string;
@@ -106,6 +107,7 @@ const ScholarshipSchema: Schema = new Schema<IScholarship>(
       documentsToSubmit: [{ type: String, trim: true }],
     },
     deadline: { type: String, required: true },
+    openingDate: { type: String, trim: true }, // When applications open
     applicationLink: { 
       type: String, 
       required: true, 
@@ -143,6 +145,7 @@ const ScholarshipSchema: Schema = new Schema<IScholarship>(
 // Indexes for better query performance
 ScholarshipSchema.index({ provider: 1 });
 ScholarshipSchema.index({ deadline: 1 });
+ScholarshipSchema.index({ openingDate: 1 });
 ScholarshipSchema.index({ value: -1 });
 ScholarshipSchema.index({ 'eligibility.degreeLevels': 1 });
 

--- a/scripts/seed-database.ts
+++ b/scripts/seed-database.ts
@@ -163,6 +163,7 @@ const seedScholarships = [
       documentsToSubmit: ['Personal essays', 'CV/Resume', 'Recommendation letters', 'Academic transcripts', 'Stanford application']
     },
     deadline: '2024-10-10',
+    openingDate: '2024-08-01',
     applicationLink: 'https://knight-hennessy.stanford.edu/apply',
     selectionCriteria: ['Leadership', 'Independence', 'Purpose'],
     renewalConditions: 'Maintain good academic standing and participate in leadership development activities',

--- a/types/index.ts
+++ b/types/index.ts
@@ -144,6 +144,7 @@ export interface Scholarship {
     documentsToSubmit?: string[];
   };
   deadline: string;
+  openingDate?: string; // When applications open
   applicationLink: string;
   selectionCriteria: string[];
   renewalConditions?: string;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add scholarship opening dates and refine status display to improve clarity and user experience.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, scholarships not yet open were sometimes marked as 'Not Eligible', which was misleading. This change separates opening status from eligibility, allowing users to prepare applications even before the official opening date.