### PR TITLE
Build Next.js app with type error

### DIFF
--- a/app/api/ai/review-application/route.ts
+++ b/app/api/ai/review-application/route.ts
@@ -50,7 +50,7 @@ async function generateAIResponse(prompt: string): Promise<string> {
 /**
  * Craft AI review prompt based on requirement and document content
  */
-export function craftReviewPrompt(
+function craftReviewPrompt(
   requirement: any,
   document: any,
   application: any,
@@ -172,7 +172,7 @@ IMPORTANT RULES:
 /**
  * Parse AI response and validate structure
  */
-export function parseAIResponse(response: string): any {
+function parseAIResponse(response: string): any {
   try {
     // Clean the response - remove any markdown formatting
     let cleanedResponse = response.trim();


### PR DESCRIPTION
Remove `export` from helper functions in API route to fix build error.

Next.js API routes only allow specific HTTP method handlers (e.g., `GET`, `POST`) to be exported. Exporting helper functions like `craftReviewPrompt` and `parseAIResponse` caused a type error during the build process.

---
<a href="https://cursor.com/background-agent?bcId=bc-09a28294-bc08-4a19-b72b-e6b1789e9875">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09a28294-bc08-4a19-b72b-e6b1789e9875">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>