### PR TITLE
Fix scholarship page translation display

### DIFF
--- a/app/(user-portal)/scholarships/[id]/page.tsx
+++ b/app/(user-portal)/scholarships/[id]/page.tsx
@@ -33,12 +33,14 @@ import { useScholarship } from '@/hooks/use-scholarships';
 import { toast } from 'sonner';
 import { getScholarshipStatus, formatDeadline } from '@/lib/scholarship-status';
 import { ApplicationPackageBuilder } from '@/components/applications/ApplicationPackageBuilder';
+import { usePageTranslation } from '@/hooks/useTranslation';
 
 function ScholarshipDetailContent() {
   const router = useRouter();
   const params = useParams();
   const { data: session, status } = useSession();
   const scholarshipId = params.id as string;
+  const { t } = usePageTranslation('scholarships');
   
   const { scholarship, isLoading, isError, mutate } = useScholarship(scholarshipId);
   
@@ -72,7 +74,11 @@ function ScholarshipDetailContent() {
   };
 
   // Get scholarship status using the unified utility
-  const scholarshipStatus = scholarship ? getScholarshipStatus(scholarship.deadline, scholarship.openingDate) : null;
+  const scholarshipStatus = scholarship ? getScholarshipStatus(
+    scholarship.deadline,
+    scholarship.openingDate,
+    { tp: (k, v) => t(k as any, v) }
+  ) : null;
 
   // Check if user is eligible based on basic criteria
   const checkBasicEligibility = () => {


### PR DESCRIPTION
Pass the page-scoped translator to `getScholarshipStatus` to resolve untranslated keys on the scholarship details page.

---
<a href="https://cursor.com/background-agent?bcId=bc-133c00fb-1ab8-49d7-9513-37c4f2ac22e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-133c00fb-1ab8-49d7-9513-37c4f2ac22e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

